### PR TITLE
パスワードリセット機能実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 /config/master.key
 
 .env
+.env
+.env.local
+.env.production

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ end
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'letter_opener_web', '~> 2.0'
 end
 
 gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,10 +66,13 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     bcrypt (3.1.20)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    childprocess (5.0.0)
     concurrent-ruby (1.2.3)
     crass (1.0.6)
     date (3.3.4)
@@ -103,6 +106,16 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -132,6 +145,7 @@ GEM
     pg (1.5.6)
     psych (5.1.2)
       stringio
+    public_suffix (5.1.1)
     puma (5.6.8)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -176,7 +190,10 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.3.0)
+      strscan
     stringio (3.1.0)
+    strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -199,6 +216,7 @@ DEPENDENCIES
   devise_token_auth
   dockerfile-rails (>= 1.6)
   dotenv-rails
+  letter_opener_web (~> 2.0)
   pg (~> 1.1)
   puma (~> 5.0)
   rack-cors

--- a/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    module Auth
+      class PasswordsController < DeviseTokenAuth::PasswordsController
+        before_action :configure_permitted_parameters, if: :devise_controller?
+        
+        protected
+        
+        def configure_permitted_parameters
+          devise_parameter_sanitizer.permit(:account_update, keys: [:password, :password_confirmation, :reset_password_token])
+        end
+
+        def resource_params
+          params.permit(:email, :password, :password_confirmation, :reset_password_token, :redirect_url)
+        end
+
+        def redirect_options
+          {
+            allow_other_host: true
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p><%= t(:welcome).capitalize + ' ' + @email %>!</p>
+
+<p><%= t '.confirm_link_msg' %> </p>
+
+<p><%= link_to t('.confirm_account_link'), confirmation_url(@resource, {confirmation_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url']}).html_safe %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t(:hello).capitalize %> <%= @resource.email %>!</p>
+
+<p><%= t '.request_reset_link_msg' %></p>
+
+<%
+reset_password_url = "#{DeviseTokenAuth.default_password_reset_url}?reset_password_token=#{@token}&uid=#{@resource.uid}"
+%>
+<p><%= link_to t('.password_change_link'), reset_password_url.html_safe %></p>
+
+<p><%= t '.ignore_mail_msg' %></p>
+<p><%= t '.no_changes_msg' %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,4 +65,18 @@ Rails.application.configure do
   config.hosts << "api"
   config.hosts << "host.docker.internal"
   config.hosts << "sound-hit-back.fly.dev"
+
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+  Rails.application.routes.default_url_options[:host] = ENV['FRONT_HOST']
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'localhost', 
+    user_name: ENV['MAILER_SENDER'],
+    password: ENV['MAILER_PASSWORD'],
+    authentication: 'plain',
+    enable_starttls_auto: true
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  Rails.application.routes.default_url_options[:host] = ENV['FRONT_HOST']
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    port:                 587,
+    domain:               'https://sound-hit.vercel.app',
+    user_name:            ENV['MAILER_SENDER'],
+    password:             ENV['MAILER_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true 
+  }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['MAILER_SENDER']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -7,6 +7,8 @@ DeviseTokenAuth.setup do |config|
   # each request.
   config.change_headers_on_each_request = false
 
+  config.require_client_password_reset_token = true
+
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
   config.token_lifespan = 1.months
@@ -63,4 +65,5 @@ DeviseTokenAuth.setup do |config|
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
   # config.send_confirmation_email = true
+  config.default_password_reset_url = "#{ENV['FRONT_REDIRECT_URL']}/password/change"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
-        registrations: 'api/v1/auth/registrations'
+        registrations: 'api/v1/auth/registrations',
+        passwords: 'api/v1/auth/passwords'
       }
 
       namespace :auth do


### PR DESCRIPTION
## 概要

- devise-token-authを使用したパスワードリセット機能の実装

## やったこと

- letter_opener_webのインストール
- リダイレクト先のURLやホストの環境変数の設定
- カスタムコントローラーとしてredirect_urlなどをparams.permitの追加
- パスワードの新規登録としてgmailからメールが届くように実装