### PR TITLE
fly.io常時起動

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ console_command = '/rails/bin/rails console'
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
## 概要

- fly.ioのマシーン常時起動

## やったこと

- fly.tomlの min_machines_running を1に変更することでマシーンを常時稼働にしました。